### PR TITLE
Make PreparedQueuePair not clone

### DIFF
--- a/ibverbs/src/lib.rs
+++ b/ibverbs/src/lib.rs
@@ -787,7 +787,6 @@ impl<'res> QueuePairBuilder<'res> {
 /// let host1end = host1.recv();
 /// let qp = pqp.handshake(host1end);
 /// ```
-#[derive(Clone)]
 pub struct PreparedQueuePair {
     ctx: Arc<Context>,
     qp: *mut ffi::ibv_qp,


### PR DESCRIPTION
`PreparedQueuePair` should not be clone. This type contains a raw pointer which would allow you to clone it, consume the clone by calling `handshake` and then the original could accidentally cause a double free on drop.


Tested by building locally 